### PR TITLE
Replace Eval as I (initialization effect) with Lazy

### DIFF
--- a/src/main/scala/me/scf37/fpscala2/Main.scala
+++ b/src/main/scala/me/scf37/fpscala2/Main.scala
@@ -2,7 +2,6 @@ package me.scf37.fpscala2
 
 import cats.Applicative
 import cats.Defer
-import cats.Eval
 import cats.data.EitherT
 import cats.effect.ExitCode
 import cats.effect.IO
@@ -14,6 +13,7 @@ import com.typesafe.config.ConfigFactory
 import me.scf37.config3.Config3
 import me.scf37.config3.Config3.PrintedConfig
 import me.scf37.fpscala2.db.sql.SqlEffect
+import me.scf37.fpscala2.module.Lazy
 import me.scf37.fpscala2.module.config.ApplicationConfig
 
 object Main extends IOApp {
@@ -35,10 +35,10 @@ object Main extends IOApp {
 
       appConfig = ApplicationConfig.load(config)
 
-      app = new Application[Eval, IO, SqlEffect[IO, ?]](appConfig)
-      server = app.serverModule.server.value
+      app = new Application[Lazy, IO, SqlEffect[IO, ?]](appConfig)
+      server <- EitherT.right(IO.fromEither(app.serverModule.server.value))
       _ <- EitherT.right(IO(server()))
-    } yield (())
+    } yield ()
 
     startedApp.value.flatMap {
 

--- a/src/main/scala/me/scf37/fpscala2/db/sql/SqlTxManager.scala
+++ b/src/main/scala/me/scf37/fpscala2/db/sql/SqlTxManager.scala
@@ -18,7 +18,7 @@ import scala.util.Try
   * JDBC transactions are run on separate thread pool to avoid suspensions of IO threads
   *
   * @param ds data source to use
-  * @param poolSize maximum number of parallel transactions
+  * @param jdbcPool thread pool for synchronous JDBC code
   * @param alwaysRollback Always rollback transaction, useful for tests
   * @tparam F generic effect
   */

--- a/src/main/scala/me/scf37/fpscala2/module/Later.scala
+++ b/src/main/scala/me/scf37/fpscala2/module/Later.scala
@@ -1,7 +1,5 @@
 package me.scf37.fpscala2.module
 
-import cats.Eval
-
 /**
   * Typeclass for monads supporting lazy evaluation and result memoization.
   * Both properties are required for initialization effect.
@@ -15,7 +13,7 @@ trait Later[I[_]] {
 object Later {
   def apply[I[_]: Later]: Later[I] = implicitly[Later[I]]
 
-  implicit val evalLater: Later[Eval] = new Later[Eval] {
-    override def later[A](f: => A): Eval[A] = cats.Later(f)
+  implicit val lazyInstance: Later[Lazy] = new Later[Lazy] {
+    override def later[A](f: => A): Lazy[A] = Lazy(f)
   }
 }

--- a/src/main/scala/me/scf37/fpscala2/module/Lazy.scala
+++ b/src/main/scala/me/scf37/fpscala2/module/Lazy.scala
@@ -1,0 +1,42 @@
+package me.scf37.fpscala2.module
+
+
+import cats.MonadError
+
+import scala.util.Try
+
+/**
+  * Lazy monad.
+  *
+  * It is synchronous monad with built in memoization, capable to capture exceptions.
+  *
+  * Unlike cats.Eval.later, memoization is kept for map/flatMap operations as well which is
+  * required for initialization effect to make singletons
+  *
+  * @param f
+  * @tparam T
+  */
+class Lazy[T] private (f: => Either[Throwable, T]) {
+  lazy val value: Either[Throwable, T] = f
+}
+
+object Lazy {
+  def apply[T](value: => T): Lazy[T] = new Lazy(Try(value).toEither)
+
+  implicit val MonadError: MonadError[Lazy, Throwable] = new MonadError[Lazy, Throwable] {
+
+    override def flatMap[A, B](fa: Lazy[A])(f: A => Lazy[B]): Lazy[B] = new Lazy(
+      fa.value.flatMap(v => f(v).value)
+    )
+
+    override def tailRecM[A, B](a: A)(f: A => Lazy[Either[A, B]]): Lazy[B] = ???
+
+    override def raiseError[A](e: Throwable): Lazy[A] = new Lazy(Left(e))
+
+    override def handleErrorWith[A](fa: Lazy[A])(f: Throwable => Lazy[A]): Lazy[A] = ???
+
+    override def pure[A](x: A): Lazy[A] = new Lazy[A](Right(x))
+  }
+}
+
+

--- a/src/test/scala/me/scf37/fpscala2/acceptance/TodoAcceptanceTest.scala
+++ b/src/test/scala/me/scf37/fpscala2/acceptance/TodoAcceptanceTest.scala
@@ -1,20 +1,20 @@
 package me.scf37.fpscala2.acceptance
 
-import cats.Eval
 import cats.effect.IO
 import com.twitter.finagle.http.RequestBuilder
 import me.scf37.fpscala2.int.IntegrationApp
+import me.scf37.fpscala2.module.Lazy
 import me.scf37.fpscala2.psql.EmbeddedPostgres
 import org.scalatest.FreeSpec
 
 class TodoAcceptanceTest extends FreeSpec {
   import me.scf37.fpscala2.db.sql._
-  val app = IntegrationApp.make[Eval, IO, SqlEffect[IO, ?]](
+  val app = IntegrationApp.make[Lazy, IO, SqlEffect[IO, ?]](
     db = EmbeddedPostgres.acceptanceInstance,
     alwaysRollback = false
   )
-  val service = app.webModule.service.value
-  val om = app.commonModule.json.value
+  val service = app.webModule.service.value.right.get
+  val om = app.commonModule.json.value.right.get
 
   def d = System.nanoTime().toString
 

--- a/src/test/scala/me/scf37/fpscala2/dao/TodoDaoTest.scala
+++ b/src/test/scala/me/scf37/fpscala2/dao/TodoDaoTest.scala
@@ -6,7 +6,7 @@ import me.scf37.fpscala2.int.IntegrationTest
 import me.scf37.fpscala2.model.Todo
 
 class TodoDaoTest extends IntegrationTest {
-  val dao = app.daoModule.todoDao.value
+  val dao = app.daoModule.todoDao.value.right.get
 
   "basic CRUD" in db {
     for {
@@ -57,6 +57,6 @@ class TodoDaoTest extends IntegrationTest {
   }
 
   private def db[A](value: SqlEffect[IO, A]): Unit = {
-    app.dbModule.tx.value.tx(value).unsafeRunSync()
+    app.dbModule.tx.value.right.get.tx(value).unsafeRunSync()
   }
 }

--- a/src/test/scala/me/scf37/fpscala2/int/IntegrationTest.scala
+++ b/src/test/scala/me/scf37/fpscala2/int/IntegrationTest.scala
@@ -1,7 +1,7 @@
 package me.scf37.fpscala2.int
 
-import cats.Eval
 import cats.effect.IO
+import me.scf37.fpscala2.module.Lazy
 import me.scf37.fpscala2.psql.EmbeddedPostgres
 import org.scalatest.FreeSpec
 
@@ -11,7 +11,7 @@ abstract class IntegrationTest extends FreeSpec {
 
 object IntegrationTest {
   import me.scf37.fpscala2.db.sql._
-  lazy val app = IntegrationApp.make[Eval, IO, SqlEffect[IO, ?]](
+  lazy val app = IntegrationApp.make[Lazy, IO, SqlEffect[IO, ?]](
     db = EmbeddedPostgres.instance,
     alwaysRollback = true
   )

--- a/src/test/scala/me/scf37/fpscala2/web/WebTest.scala
+++ b/src/test/scala/me/scf37/fpscala2/web/WebTest.scala
@@ -1,15 +1,15 @@
 package me.scf37.fpscala2.web
 
-import cats.Eval
 import cats.effect.IO
 import com.twitter.finagle.http.RequestBuilder
 import com.twitter.io.Buf
 import me.scf37.fpscala2.memory.MemoryApp
+import me.scf37.fpscala2.module.Lazy
 import org.scalatest.FreeSpec
 
 class WebTest extends FreeSpec {
-  val app = new MemoryApp[Eval, IO]
-  val service = app.webModule.service.value
+  val app = new MemoryApp[Lazy, IO]
+  val service = app.webModule.service.value.right.get
 
   "404 is empty response" in {
     val r = service(url("/404").buildGet()).unsafeRunSync()


### PR DESCRIPTION
Eval.later does not keep memoization property when combined using flatMap making created objects non-singletons.
Custom Lazy monad memoizes always.